### PR TITLE
feat: make compatible with LM Studio OpenAI endpoint

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -272,7 +272,7 @@ class OllamaModelInfo(BaseModel):
 
     name: str = Field(..., description="Model name")
     model: str = Field(..., description="Model identifier")
-    modified_at: str = Field(..., description="Last modified timestamp")
+    modified_at: Optional[str] = Field(None, description="Last modified timestamp")
     size: int = Field(..., description="Model size in bytes")
     digest: str = Field(..., description="Model digest")
     details: Optional[Dict[str, Any]] = Field(None, description="Model details")
@@ -540,7 +540,7 @@ class OpenAIModel(BaseModel):
 
     id: str = Field(..., description="Model ID")
     object: Literal["model"] = Field("model", description="Object type")
-    created: int = Field(..., description="Creation timestamp")
+    created: Optional[int] = Field(None, description="Creation timestamp")
     owned_by: Optional[str] = Field(None, description="Model owner")
     permission: Optional[List[Dict[str, Any]]] = Field(
         None, description="Model permissions"

--- a/src/routers/models.py
+++ b/src/routers/models.py
@@ -95,10 +95,13 @@ async def list_models(fastapi_request: Request) -> JSONResponse:
                 # Generate a consistent digest from model ID
                 digest_hash = hashlib.sha256(model.id.encode()).hexdigest()
 
-                # Convert created timestamp to ISO format
-                modified_at = datetime.fromtimestamp(
-                    model.created, tz=timezone.utc
-                ).isoformat()
+                # Convert created timestamp to ISO format if present
+                if model.created:
+                    modified_at = datetime.fromtimestamp(
+                        model.created, tz=timezone.utc
+                    ).isoformat()
+                else:
+                    modified_at = None
 
                 ollama_model = OllamaModelInfo(  # type: ignore[call-arg]
                     name=model.id,


### PR DESCRIPTION
## Summary
Make the codebase compatible with LM Studio's OpenAI API endpoint.

**Example response from LM Studio `/v1/models`**
```
{
  "data": [
    {
      "id": "qwen3.5-35b-a3b",
      "object": "model",
      "owned_by": "organization_owner"
    },
    {
      "id": "qwen3.5-122b-a10b",
      "object": "model",
      "owned_by": "organization_owner"
    }
  ],
  "object": "list"
}

```