### PR TITLE
fix: use message field in /api/chat streaming responses (issue #33)

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -98,7 +98,7 @@ class OllamaChatMessage(BaseModel):
     role: Literal["system", "user", "assistant", "tool"] = Field(
         ..., description="Message role"
     )
-    content: str = Field(..., description="Message content")
+    content: str = Field("", description="Message content")
     images: Optional[List[str]] = Field(None, description="Base64 encoded images")
     tool_calls: Optional[List[Dict[str, Any]]] = Field(
         None, description="Tool calls made by assistant"

--- a/src/routers/chat.py
+++ b/src/routers/chat.py
@@ -123,6 +123,7 @@ async def stream_response(
     url = f"{settings.OPENAI_API_BASE_URL}/chat/completions"
 
     try:
+        done_emitted = False
         # Use stream_with_retry for streaming requests
         async for chunk in client.stream_with_retry(
             "POST",
@@ -137,14 +138,16 @@ async def stream_response(
                     continue
 
                 if line == "data: [DONE]":
-                    # Send final chunk
-                    final_chunk = translator.translate_streaming_response(
-                        "[DONE]",  # type: ignore
-                        original_request,
-                        is_last_chunk=True,
-                    )
-                    if final_chunk:
-                        yield json.dumps(final_chunk) + "\n"
+                    # Only emit the sentinel done chunk if no finish_reason
+                    # chunk already signalled done (avoids duplicate done chunks)
+                    if not done_emitted:
+                        final_chunk = translator.translate_streaming_response(
+                            "[DONE]",  # type: ignore
+                            original_request,
+                            is_last_chunk=True,
+                        )
+                        if final_chunk:
+                            yield json.dumps(final_chunk) + "\n"
                     return
 
                 if line.startswith("data: "):
@@ -158,6 +161,8 @@ async def stream_response(
                         )
 
                         if ollama_chunk:
+                            if ollama_chunk.get("done"):
+                                done_emitted = True
                             yield json.dumps(ollama_chunk) + "\n"
 
                     except json.JSONDecodeError as e:

--- a/src/translators/chat.py
+++ b/src/translators/chat.py
@@ -178,6 +178,14 @@ class ChatTranslator(
             if isinstance(openai_chunk, str):
                 if openai_chunk.strip() == "[DONE]":
                     # Final chunk - return done response
+                    if isinstance(original_request, OllamaChatRequest):
+                        return {
+                            "model": original_request.model,
+                            "created_at": self.get_iso_timestamp(),
+                            "message": {"role": "assistant", "content": ""},
+                            "done": True,
+                            "done_reason": "stop",
+                        }
                     return {
                         "model": original_request.model,
                         "created_at": self.get_iso_timestamp(),
@@ -219,17 +227,27 @@ class ChatTranslator(
                             delta["function_call"]
                         )
 
-            # Build Ollama streaming response
-            response = {
-                "model": self.reverse_map_model_name(
-                    openai_chunk.get("model", original_request.model)
-                    if isinstance(openai_chunk, dict)
-                    else original_request.model
-                ),
-                "created_at": self.get_iso_timestamp(),
-                "response": content,
-                "done": finish_reason is not None,
-            }
+            model_name = self.reverse_map_model_name(
+                openai_chunk.get("model", original_request.model)
+                if isinstance(openai_chunk, dict)
+                else original_request.model
+            )
+
+            # Build Ollama streaming response — format differs by endpoint type
+            if isinstance(original_request, OllamaChatRequest):
+                response = {
+                    "model": model_name,
+                    "created_at": self.get_iso_timestamp(),
+                    "message": {"role": "assistant", "content": content or ""},
+                    "done": finish_reason is not None,
+                }
+            else:
+                response = {
+                    "model": model_name,
+                    "created_at": self.get_iso_timestamp(),
+                    "response": content,
+                    "done": finish_reason is not None,
+                }
 
             # Add finish reason if present
             if finish_reason:

--- a/tests/unit/translators/test_chat.py
+++ b/tests/unit/translators/test_chat.py
@@ -416,6 +416,63 @@ class TestChatTranslatorStreamingChunks:
         assert result["response"] == "Test"
         assert result["model"] == "llama2"
 
+    def test_translate_streaming_chunk_chat_with_content(
+        self, chat_translator, ollama_chat_request
+    ):
+        """Chat request streaming chunk uses message field, not response."""
+        chunk = {
+            "id": "chatcmpl-123",
+            "object": "chat.completion.chunk",
+            "created": 1234567890,
+            "model": "gpt-4",
+            "choices": [
+                {"index": 0, "delta": {"content": "Hello"}, "finish_reason": None}
+            ],
+        }
+
+        result = chat_translator.translate_streaming_response(
+            chunk, ollama_chat_request
+        )
+
+        assert result is not None
+        assert "message" in result
+        assert result["message"]["role"] == "assistant"
+        assert result["message"]["content"] == "Hello"
+        assert "response" not in result
+        assert result["done"] is False
+
+    def test_translate_streaming_chunk_chat_done(
+        self, chat_translator, ollama_chat_request
+    ):
+        """[DONE] with chat request yields message field, not response."""
+        result = chat_translator.translate_streaming_response(
+            "[DONE]", ollama_chat_request
+        )
+
+        assert result is not None
+        assert "message" in result
+        assert result["message"]["role"] == "assistant"
+        assert result["message"]["content"] == ""
+        assert "response" not in result
+        assert result["done"] is True
+        assert result["done_reason"] == "stop"
+
+    def test_translate_streaming_chunk_generate_still_uses_response(
+        self, chat_translator, ollama_generate_request
+    ):
+        """Generate request streaming still uses response field (unchanged)."""
+        chunk = {
+            "choices": [{"delta": {"content": "Hi"}, "finish_reason": None}]
+        }
+
+        result = chat_translator.translate_streaming_response(
+            chunk, ollama_generate_request
+        )
+
+        assert result is not None
+        assert result["response"] == "Hi"
+        assert "message" not in result
+
 
 class TestChatTranslatorErrorHandling:
     """Test error handling in the translator."""
@@ -543,10 +600,10 @@ class TestChatTranslatorIntegration:
             if result:
                 responses.append(result)
 
-        # Check responses
+        # Check responses — chat endpoint uses message field, not response
         assert len(responses) == 4
-        assert responses[0]["response"] == "Hello"
-        assert responses[1]["response"] == " there"
-        assert responses[2]["response"] == "!"
+        assert responses[0]["message"]["content"] == "Hello"
+        assert responses[1]["message"]["content"] == " there"
+        assert responses[2]["message"]["content"] == "!"
         assert responses[3]["done"] is True
         assert all(r["model"] == "mistral" for r in responses)


### PR DESCRIPTION
## Summary

- Fixes #33: `/api/chat` streaming chunks incorrectly returned a `response` field instead of `message: {role, content}` as required by the Ollama API spec
- `/api/generate` streaming is unchanged and continues to use the `response` field
- Added 3 new tests covering the corrected chat streaming format and a regression test confirming generate format is unaffected
- Updated one existing integration test that was asserting the old (wrong) format

## Test plan

- `python -m pytest tests/unit/translators/test_chat.py -v` — all 27 tests pass
- `python -m pytest tests/unit/ -v` — all 336 tests pass, 1 skipped
- Manual: `curl .../api/chat` with streaming returns `{"message": {"role": "assistant", "content": "..."}, "done": false}` chunks
- Manual: `curl .../api/generate` with streaming still returns `{"response": "...", "done": false}` chunks